### PR TITLE
calimero fix sync accounts

### DIFF
--- a/packages/frontend/src/services/PrivateShard.js
+++ b/packages/frontend/src/services/PrivateShard.js
@@ -2,10 +2,9 @@ import createError from 'http-errors';
 
 import CONFIG from '../config';
 
-export async function syncPrivateShardAccount({ accountId, publicKey, signature, shardInfo }) {
+export async function syncPrivateShardAccount({ accountId, signature, shardInfo }) {
     const postData = {
         accountId,
-        publicKey,
         signature,
         shardId: shardInfo.shardId,
     };

--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -972,7 +972,7 @@ export default class Wallet {
             CONFIG.NETWORK_ID
         );
         const blockNumberSignature = Buffer.from(signed.signature).toString('base64');
-        return { blockNumber, blockNumberSignature };
+        return { blockNumber, blockNumberSignature, publicKey: signed.publicKey.toString() };
     }
 
     async postSignedJson(path, options) {


### PR DESCRIPTION
Previous implementation didn't sync accounts if the user signs in without creating a function call access key.